### PR TITLE
JW-1003 Run driver tests only nightly

### DIFF
--- a/CIScripts/TestIntegration.ps1
+++ b/CIScripts/TestIntegration.ps1
@@ -67,7 +67,10 @@ Test-TCPCommunication -Session $Sessions[0] -TestConfiguration $TestConfiguratio
 Test-ICMPoMPLSoGRE -Session1 $Sessions[0] -Session2 $Sessions[1] -TestConfiguration $TestConfiguration
 Test-TCPoMPLSoGRE -Session1 $Sessions[0] -Session2 $Sessions[1] -TestConfiguration $TestConfiguration
 Test-SNAT -Session $Sessions[0] -SNATConfiguration $SNATConfiguration -TestConfiguration $TestConfiguration
-Test-DockerDriver -Session $Sessions[0] -TestConfiguration $TestConfiguration
+
+if($Env:RUN_DRIVER_TESTS) {
+    Test-DockerDriver -Session $Sessions[0] -TestConfiguration $TestConfiguration
+}
 
 Write-Host "Removing VMs..."
 Remove-TestbedVMs -VMNames $VMNames -PowerCLIScriptPath $PowerCLIScriptPath -VIServerAccessData $VIServerAccessData


### PR DESCRIPTION
Requires changes in Jenkins.

Added parameter: `RUN_DRIVER_TESTS (String). Default 0`
Build periodically with parameters modified to: `0 21 * * * % LEAK_TEST_DURATION=4; RUN_DRIVER_TESTS=1`