### PR TITLE
JW-1006 Linked clone support for testbed VMs

### DIFF
--- a/CIScripts/VMUtils.ps1
+++ b/CIScripts/VMUtils.ps1
@@ -59,12 +59,21 @@ function New-TestbedVMs {
 
         Write-Host "Creating and starting $VMName"
         $ResourcePool = Get-ResourcePool -Name $VMCreationSettings.ResourcePoolName
-        $Template = Get-Template -Name $VMCreationSettings.TemplateName
+        $Template = Get-VM -Name $VMCreationSettings.TemplateName
         $CustomizationSpec = Get-OSCustomizationSpec -Name $VMCreationSettings.CustomizationSpecName
 
         $AllDatastores = Get-Datastore -Name $VMCreationSettings.DatastoresList
         $EmptiestDatastore = ($AllDatastores | Sort-Object -Property FreeSpaceGB -Descending)[0]
-        $BaseSnapshot = (Get-Snapshot -VM $Template)[0]
+
+        if (!$Template) {
+            Set-Template -Template $VMCreationSettings.TemplateName -ToVM
+            $Template = Get-VM -Name $VMCreationSettings.TemplateName
+        }
+        $BaseSnapshot = Get-Snapshot -VM $Template
+        if ($BaseSnapshot.count -ne 1) {
+            Write-Host 'VM base image should have one snapshot for linked clones.'
+            exit 1
+        }
 
         New-VM -VM $Template -Name $VMName -LinkedClone -ReferenceSnapshot $BaseSnapshot -Datastore $EmptiestDatastore -ResourcePool $ResourcePool `
         -Location $VMCreationSettings.NewVMLocation -OSCustomizationSpec $CustomizationSpec -ErrorAction Stop -Verbose | Out-Null

--- a/CIScripts/VMUtils.ps1
+++ b/CIScripts/VMUtils.ps1
@@ -64,9 +64,10 @@ function New-TestbedVMs {
 
         $AllDatastores = Get-Datastore -Name $VMCreationSettings.DatastoresList
         $EmptiestDatastore = ($AllDatastores | Sort-Object -Property FreeSpaceGB -Descending)[0]
+        $BaseSnapshot = (Get-Snapshot -VM $Template)[0]
 
-        New-VM -Name $VMName -Template $Template -Datastore $EmptiestDatastore -ResourcePool $ResourcePool -Location $VMCreationSettings.NewVMLocation `
-            -OSCustomizationSpec $CustomizationSpec -ErrorAction Stop -Verbose | Out-Null
+        New-VM -VM $Template -Name $VMName -LinkedClone -ReferenceSnapshot $BaseSnapshot -Datastore $EmptiestDatastore -ResourcePool $ResourcePool `
+        -Location $VMCreationSettings.NewVMLocation -OSCustomizationSpec $CustomizationSpec -ErrorAction Stop -Verbose | Out-Null
         #New-HardDisk -VM $vm -CapacityGB 2 -Datastore DUMP -StorageFormat thin -Controller (Get-ScsiController -VM $vm) -Persistence IndependentPersistent -Verbose # TODO: Fix after JW-796
         Start-VM -VM $VMName -Confirm:$false -ErrorAction Stop -Verbose | Out-Null
     }


### PR DESCRIPTION
It is using powered off VM placed in Templates folder as parent for spawned testbed. 
VM has to have snapshot which is used as base disk for child VMs disks. Possibly 
base snapshot could be set as another property in `NewVMCreationSettings` and be set 
from env variables in `SetCommonVariablesForNewVMsFromEnv.ps1`