### PR TITLE
JW-1194: Don't copy libxml2.dll to artifacts

### DIFF
--- a/CIScripts/VMUtils.ps1
+++ b/CIScripts/VMUtils.ps1
@@ -168,7 +168,7 @@ function New-TestbedVMs {
         Write-Host "Copying Agent"
         Copy-Item -ToSession $Session -Path "agent\contrail-vrouter-agent.msi" -Destination C:\Artifacts\
 
-        Write-Host "Copying Agent test executables and dlls"
+        Write-Host "Copying Agent test executables"
         $AgentTextExecutables = Get-ChildItem .\agent | Where-Object {$_.Name -match '^[\W\w]*test[\W\w]*.exe$'}
 
         #Test executables from schema/test do not follow the convention
@@ -179,7 +179,6 @@ function New-TestbedVMs {
             Write-Host "    Copying $TestExecutable"
             Copy-Item -ToSession $Session -Path "agent\$TestExecutable" -Destination C:\Artifacts\
         }
-        Copy-Item -ToSession $Session -Path "agent\libxml2.dll" -Destination C:\Artifacts\
 
         Write-Host "Copying test configuration files and test data"
         Copy-Item -ToSession $Session -Path "agent\vnswa_cfg.ini" -Destination C:\Artifacts\


### PR DESCRIPTION
Copying libxml2.dll to artifacts for testing is unnecessary, as the only binary using this dll is vtest.exe, which has the libxml2.dll properly installed by utils.msi anyway.

Followup question:
Should the build-all job put the the dlls in the build/bin at all?