### PR TITLE
JW-1229 Consolidate and flatten build output paths.

### DIFF
--- a/CIScripts/BuildAll.ps1
+++ b/CIScripts/BuildAll.ps1
@@ -19,8 +19,8 @@ Invoke-ContrailCommonActions -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -VSSet
 
 $ReleaseMode = [bool]::Parse($Env:BUILD_IN_RELEASE_MODE)
 
-Invoke-DockerDriverBuild -DriverSrcPath $Env:DRIVER_SRC_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH
-Invoke-ExtensionBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode
-Invoke-AgentBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode
+Invoke-DockerDriverBuild -DriverSrcPath $Env:DRIVER_SRC_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -OutputPath "output/docker_driver"
+Invoke-ExtensionBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode -OutputPath "output/vrouter"
+Invoke-AgentBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode -OutputPath "output/agent"
 
 $Job.Done()

--- a/CIScripts/BuildAll.ps1
+++ b/CIScripts/BuildAll.ps1
@@ -19,12 +19,16 @@ Invoke-ContrailCommonActions -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -VSSet
 
 $ReleaseMode = [bool]::Parse($Env:BUILD_IN_RELEASE_MODE)
 
-New-Item -Path "output" -Name "docker_driver" -ItemType directory
-New-Item -Path "output" -Name "vrouter" -ItemType directory
-New-Item -Path "output" -Name "agent" -ItemType directory
+$DockerDriverOutputDir = "output/docker_driver"
+$vRouterOutputDir = "output/vrouter"
+$AgentOutputDir = "output/agent"
 
-Invoke-DockerDriverBuild -DriverSrcPath $Env:DRIVER_SRC_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -OutputPath "output/docker_driver"
-Invoke-ExtensionBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode -OutputPath "output/vrouter"
-Invoke-AgentBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode -OutputPath "output/agent"
+New-Item -ItemType directory -Path $DockerDriverOutputDir
+New-Item -ItemType directory -Path $vRouterOutputDir
+New-Item -ItemType directory -Path $AgentOutputDir
+
+Invoke-DockerDriverBuild -DriverSrcPath $Env:DRIVER_SRC_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -OutputPath $DockerDriverOutputDir
+Invoke-ExtensionBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode -OutputPath $vRouterOutputDir
+Invoke-AgentBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode -OutputPath $AgentOutputDir
 
 $Job.Done()

--- a/CIScripts/BuildAll.ps1
+++ b/CIScripts/BuildAll.ps1
@@ -19,6 +19,10 @@ Invoke-ContrailCommonActions -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -VSSet
 
 $ReleaseMode = [bool]::Parse($Env:BUILD_IN_RELEASE_MODE)
 
+New-Item -Path "output" -Name "docker_driver" -ItemType directory
+New-Item -Path "output" -Name "vrouter" -ItemType directory
+New-Item -Path "output" -Name "agent" -ItemType directory
+
 Invoke-DockerDriverBuild -DriverSrcPath $Env:DRIVER_SRC_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -OutputPath "output/docker_driver"
 Invoke-ExtensionBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode -OutputPath "output/vrouter"
 Invoke-AgentBuild -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH -SigntoolPath $Env:SIGNTOOL_PATH -CertPath $Env:CERT_PATH -CertPasswordFilePath $Env:CERT_PASSWORD_FILE_PATH -ReleaseMode $ReleaseMode -OutputPath "output/agent"

--- a/CIScripts/BuildFunctions.ps1
+++ b/CIScripts/BuildFunctions.ps1
@@ -161,16 +161,16 @@ function Invoke-ExtensionBuild {
         }
     })
 
-    $vRouterMSI = "build\{0}\vrouter\extension\vRouter.msi" -f $BuildMode
-    $utilsMSI = "build\{0}\vrouter\utils\utils.msi" -f $BuildMode
+    $vRouterRoot = "build\{0}\vrouter" -f $BuildMode
+    $vRouterMSI = "$vRouterRoot\extension\vRouter.msi"
+    $utilsMSI = "$vRouterRoot\utils\utils.msi"
+    $vTestPath = "$vRouterRoot\utils\vtest\"
 
     Write-Host "Signing utilsMSI"
     Set-MSISignature -SigntoolPath $SigntoolPath -CertPath $CertPath -CertPasswordFilePath $CertPasswordFilePath -MSIPath $utilsMSI
 
     Write-Host "Signing vRouterMSI"
     Set-MSISignature -SigntoolPath $SigntoolPath -CertPath $CertPath -CertPasswordFilePath $CertPasswordFilePath -MSIPath $vRouterMSI
-
-    $vTestPath = "build\{0}\vrouter\utils\vtest\"
 
     $Job.Step("Copying artifacts to $OutputPath", {
         Copy-Item $utilsMSI $OutputPath -Recurse -Container

--- a/CIScripts/BuildFunctions.ps1
+++ b/CIScripts/BuildFunctions.ps1
@@ -127,7 +127,7 @@ function Invoke-DockerDriverBuild {
     Set-MSISignature -SigntoolPath $SigntoolPath -CertPath $CertPath -CertPasswordFilePath $CertPasswordFilePath -MSIPath "docker-driver.msi"
 
     $Job.Step("Copying artifacts to $OutputPath", {
-        Copy-Item ./ $OutputPath
+        Copy-Item ./* $OutputPath
     })
 
     Pop-Location

--- a/CIScripts/BuildFunctions.ps1
+++ b/CIScripts/BuildFunctions.ps1
@@ -132,7 +132,6 @@ function Invoke-DockerDriverBuild {
         Copy-Item bin/* $OutputPath
     })
 
-
     $Job.PopStep()
 }
 
@@ -141,8 +140,8 @@ function Invoke-ExtensionBuild {
            [Parameter(Mandatory = $true)] [string] $SigntoolPath,
            [Parameter(Mandatory = $true)] [string] $CertPath,
            [Parameter(Mandatory = $true)] [string] $CertPasswordFilePath,
-           [Parameter(Mandatory = $false)] [bool] $ReleaseMode = $false,
-           [Parameter(Mandatory = $true)] [string] $OutputPath)
+           [Parameter(Mandatory = $true)] [string] $OutputPath,
+           [Parameter(Mandatory = $false)] [bool] $ReleaseMode = $false)
 
     $Job.PushStep("Extension build")
 
@@ -187,8 +186,8 @@ function Invoke-AgentBuild {
            [Parameter(Mandatory = $true)] [string] $SigntoolPath,
            [Parameter(Mandatory = $true)] [string] $CertPath,
            [Parameter(Mandatory = $true)] [string] $CertPasswordFilePath,
-           [Parameter(Mandatory = $false)] [bool] $ReleaseMode = $false,
-           [Parameter(Mandatory = $true)] [string] $OutputPath)
+           [Parameter(Mandatory = $true)] [string] $OutputPath,
+           [Parameter(Mandatory = $false)] [bool] $ReleaseMode = $false)
 
     $Job.PushStep("Agent build")
 
@@ -257,7 +256,7 @@ function Invoke-AgentBuild {
     $Job.Step("Copying artifacts to $OutputPath", {
         $vRouterApiPath = "build\noarch\contrail-vrouter-api\dist\contrail-vrouter-api-1.0.tar.gz"
         $testInisPath = "controller\src\vnsw\agent\test"
-        $libxmlPath = "build/bin/libxml2.dll"
+        $libxmlPath = "build\bin\libxml2.dll"
 
         Copy-Item $vRouterApiPath $OutputPath -Recurse -Container
         Copy-Item $agentMSI $OutputPath -Recurse -Container

--- a/CIScripts/BuildFunctions.ps1
+++ b/CIScripts/BuildFunctions.ps1
@@ -126,11 +126,12 @@ function Invoke-DockerDriverBuild {
 
     Set-MSISignature -SigntoolPath $SigntoolPath -CertPath $CertPath -CertPasswordFilePath $CertPasswordFilePath -MSIPath "docker-driver.msi"
 
+    Pop-Location
+
     $Job.Step("Copying artifacts to $OutputPath", {
-        Copy-Item ./* $OutputPath
+        Copy-Item bin/* $OutputPath
     })
 
-    Pop-Location
 
     $Job.PopStep()
 }

--- a/CIScripts/BuildFunctions.ps1
+++ b/CIScripts/BuildFunctions.ps1
@@ -176,7 +176,7 @@ function Invoke-ExtensionBuild {
         Copy-Item $utilsMSI $OutputPath -Recurse -Container
         Copy-Item $vRouterMSI $OutputPath -Recurse -Container
         Copy-Item $CertPath $OutputPath -Recurse -Container
-        Copy-Item -Recurse $vTestPath "$OutputPath\utils\vtest" -Recurse -Container
+        Copy-Item $vTestPath "$OutputPath\utils\vtest" -Recurse -Container
     })
 
     $Job.PopStep()

--- a/CIScripts/BuildFunctions.ps1
+++ b/CIScripts/BuildFunctions.ps1
@@ -173,10 +173,10 @@ function Invoke-ExtensionBuild {
     $vTestPath = "build\{0}\vrouter\utils\vtest\"
 
     $Job.Step("Copying artifacts to $OutputPath", {
-        Copy-Item $utilsMSI $OutputPath
-        Copy-Item $vRouterMSI $OutputPath
-        Copy-Item $CertPath $OutputPath
-        Copy-Item -Recurse $vTestPath "$OutputPath\utils\vtest"
+        Copy-Item $utilsMSI $OutputPath -Recurse -Container
+        Copy-Item $vRouterMSI $OutputPath -Recurse -Container
+        Copy-Item $CertPath $OutputPath -Recurse -Container
+        Copy-Item -Recurse $vTestPath "$OutputPath\utils\vtest" -Recurse -Container
     })
 
     $Job.PopStep()
@@ -259,11 +259,11 @@ function Invoke-AgentBuild {
         $testInisPath = "controller\src\vnsw\agent\test"
         $libxmlPath = "build/bin/libxml2.dll"
 
-        Copy-Item $vRouterApiPath $OutputPath
-        Copy-Item $agentMSI $OutputPath
-        Copy-Item -Path $rootBuildDir -Recurse -Include "*.exe" -Destination $OutputPath # This copies all test executables
+        Copy-Item $vRouterApiPath $OutputPath -Recurse -Container
+        Copy-Item $agentMSI $OutputPath -Recurse -Container
+        Copy-Item -Path $rootBuildDir -Recurse -Include "*.exe" -Destination $OutputPath -Container # This copies all test executables 
         Copy-Item -Path $testInisPath -Include "*.ini" -Destination $OutputPath
-        Copy-Item $libxmlPath $OutputPath
+        Copy-Item $libxmlPath $OutputPath -Recurse -Container
     })
 
     $Job.PopStep()


### PR DESCRIPTION
For now, we will maintain the "old" paths and the new paths, to not break any tests (we Copy-Item instead of Move-Item, pretty much). Old paths will need to be removed after test-integration-... jobs are adapted to new paths.