### PR TITLE
JW-1197: Wait for //./pipe/Contrail after enabling docker driver

### DIFF
--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -325,11 +325,6 @@ function Initialize-TestConfiguration {
         throw "Docker driver was not enabled."
     }
 
-    $Res = Test-IsVRouterExtensionEnabled -Session $Session -VMSwitchName $TestConfiguration.VMSwitchName -ForwardingExtensionName $TestConfiguration.ForwardingExtensionName
-    if ($Res -ne $true) {
-        throw "Extension was not enabled or is not running."
-    }
-
     if (!$NoNetwork) {
         New-DockerNetwork -Session $Session -TestConfiguration $TestConfiguration | Out-Null
     }


### PR DESCRIPTION
After enabling docker driver, wait for `//./pipe/Contrail` instead of waiting for extension being enabled. Docker driver starts listening on a pipe after enabling the extension, so just checking the extension creates a race.