### PR TITLE
JW-1243: Wait for agent crash longer in a loop

### DIFF
--- a/CIScripts/Test/Tests/AgentServiceTests.ps1
+++ b/CIScripts/Test/Tests/AgentServiceTests.ps1
@@ -223,7 +223,6 @@ function Test-AgentService {
             # Wait for contrail-vrouter-agent process to start
             Start-Sleep -s 2
             Invoke-AgentCrash -Session $Session
-            Start-Sleep -s 2
             Assert-AgentProcessCrashed -Session $Session
 
             Write-Host "======> Then Agent service is restarted"

--- a/CIScripts/Test/Tests/Pkt0PipeImplementationTests.ps1
+++ b/CIScripts/Test/Tests/Pkt0PipeImplementationTests.ps1
@@ -36,7 +36,6 @@ function Test-Pkt0PipeImplementation {
 
             Write-Host "======> Then Agent should crash when started"
             Enable-AgentService -Session $Session
-            Start-Sleep -s 2
             Assert-AgentProcessCrashed -Session $Session
 
             Write-Host "======> Cleanup"
@@ -90,7 +89,6 @@ function Test-Pkt0PipeImplementation {
                 -ForwardingExtensionName $TestConfiguration.ForwardingExtensionName
 
             Write-Host "======> Then Agent should crash"
-            Start-Sleep -s 3
             Assert-AgentProcessCrashed -Session $Session
 
             Write-Host "======> Cleanup"


### PR DESCRIPTION
Potential quick fix for *Agent process didn't crash. EXPECTED: Agent process crashed*.

I haven't used the constants for `TimeBetweenChecksInSecond` etc., as in other functions, because this function uses magic `AddSeconds(-5)`, so these two numbers are tightly coupled.