### PR TITLE
JW-1197 When a test fails, display docker driver logs

### DIFF
--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -106,6 +106,7 @@ function Test-IsVRouterExtensionEnabled {
 
     return $($Ext.Enabled -and $Ext.Running)
 }
+
 function Enable-DockerDriver {
     Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session,
            [Parameter(Mandatory = $true)] [string] $AdapterName,

--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -119,13 +119,18 @@ function Enable-DockerDriver {
     $TenantName = $Configuration.TenantConfiguration.Name
 
     Invoke-Command -Session $Session -ScriptBlock {
-        Push-Location $Env:ProgramData/ContrailDockerDriver
 
-        if (Test-Path log.txt) {
-            Move-Item -Force log.txt log.old.txt
+        $LogDir = "$Env:ProgramData/ContrailDockerDriver"
+
+        if (Test-Path $LogDir) {
+            Push-Location $LogDir
+
+            if (Test-Path log.txt) {
+                Move-Item -Force log.txt log.old.txt
+            }
+
+            Pop-Location
         }
-
-        Pop-Location
 
         # Nested ScriptBlock variable passing workaround
         $AdapterName = $Using:AdapterName

--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -106,7 +106,6 @@ function Test-IsVRouterExtensionEnabled {
 
     return $($Ext.Enabled -and $Ext.Running)
 }
-
 function Enable-DockerDriver {
     Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session,
            [Parameter(Mandatory = $true)] [string] $AdapterName,
@@ -119,6 +118,14 @@ function Enable-DockerDriver {
     $TenantName = $Configuration.TenantConfiguration.Name
 
     Invoke-Command -Session $Session -ScriptBlock {
+        Push-Location $Env:ProgramData/ContrailDockerDriver
+
+        if (Test-Path log.txt) {
+            Move-Item -Force log.txt log.old.txt
+        }
+
+        Pop-Location
+
         # Nested ScriptBlock variable passing workaround
         $AdapterName = $Using:AdapterName
         $ControllerIP = $Using:ControllerIP
@@ -133,7 +140,7 @@ function Enable-DockerDriver {
             $Env:OS_AUTH_URL = $Cfg.AuthUrl
             $Env:OS_TENANT_NAME = $Tenant
 
-            & "C:\Program Files\Juniper Networks\contrail-windows-docker.exe" -forceAsInteractive -controllerIP $ControllerIP -adapter "$Adapter" -vswitchName "Layered <adapter>"
+            & "C:\Program Files\Juniper Networks\contrail-windows-docker.exe" -forceAsInteractive -controllerIP $ControllerIP -adapter "$Adapter" -vswitchName "Layered <adapter>" -logLevel "Debug"
         } -ArgumentList $Configuration, $ControllerIP, $TenantName, $AdapterName | Out-Null
     }
 

--- a/CIScripts/Test/TestRunner.ps1
+++ b/CIScripts/Test/TestRunner.ps1
@@ -16,7 +16,7 @@
 . $PSScriptRoot\Tests\Pkt0PipeImplementationTests.ps1
 . $PSScriptRoot\Tests\DockerDriverMultitenancyTest.ps1
 
-function Run-Tests {
+function Run-TestsWithoutLogs {
     Param ([Parameter(Mandatory = $true)] [PSSessionT[]] $Sessions)
 
     $Job.Step("Running all integration tests", {
@@ -102,4 +102,37 @@ function Run-Tests {
             Test-DockerDriver -Session $Sessions[0] -TestConfiguration $TestConfiguration
         }
     })
+}
+
+function Run-Tests {
+    Param ([Parameter(Mandatory = $true)] [PSSessionT[]] $Sessions)
+
+    try {
+        Run-TestsWithoutLogs -Sessions $Sessions
+    }
+    catch {
+        Write-Host $_
+
+        foreach ($Session in $Sessions) {
+            if ($Session.State -eq "Opened") {
+                Write-Host
+                Write-Host "Displaying logs from $($Session.ComputerName)"
+                Invoke-Command -Session $Session {
+                    $LogPaths = @(
+                        "$Env:ProgramData/ContrailDockerDriver/log.txt",
+                        "$Env:ProgramData/ContrailDockerDriver/log.old.txt"
+                    )
+                    foreach ($Path in $LogPaths) {
+                        if (Test-Path $Path) {
+                            Write-Host
+                            Write-Host "Contents of ${Path}:"
+                            Get-Content $Path
+                        }
+                    }
+                }
+            }
+        }
+
+        throw
+    }
 }


### PR DESCRIPTION
Use -logLevel "Debug", display logs from last two runs.
(log.txt and log.old.txt).

This should help debug issue with //./pipe/Contrail not being opened
(Now the error is reported as "Docker driver was not enabled")