### PR TITLE
JW-1153: Let multihost UDP test use networks with policies

### DIFF
--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -426,9 +426,10 @@ physical_interface=$PhysIfName
 
 function Initialize-ComputeServices {
         Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session,
-            [Parameter(Mandatory = $true)] [TestConfiguration] $TestConfiguration)
+               [Parameter(Mandatory = $true)] [TestConfiguration] $TestConfiguration,
+               [Parameter(Mandatory = $false)] [Boolean] $NoNetwork = $false)
 
-        Initialize-TestConfiguration -Session $Session -TestConfiguration $TestConfiguration
+        Initialize-TestConfiguration -Session $Session -TestConfiguration $TestConfiguration -NoNetwork $NoNetwork
         New-AgentConfigFile -Session $Session -TestConfiguration $TestConfiguration
         Enable-AgentService -Session $Session
 }

--- a/CIScripts/Test/Tests/VRouterAgentTests.ps1
+++ b/CIScripts/Test/Tests/VRouterAgentTests.ps1
@@ -494,18 +494,6 @@ function Test-VRouterAgentIntegration {
         }
     }
 
-    function Initialize-ComputeNodeForFlowTests {
-        Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session,
-               [Parameter(Mandatory = $true)] [TestConfiguration] $TestConfiguration)
-
-        $TenantConfiguration = $TestConfiguration.DockerDriverConfiguration.TenantConfiguration
-
-        Initialize-ComputeNode -Session $Session -TestConfiguration $TestConfiguration `
-            -Networks @($TenantConfiguration.NetworkWithPolicy1, $TenantConfiguration.NetworkWithPolicy2)
-
-        Start-Sleep -Seconds $WAIT_TIME_FOR_AGENT_INIT_IN_SECONDS
-    }
-
     function Initialize-ComputeNode {
         Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session,
                [Parameter(Mandatory = $true)] [TestConfiguration] $TestConfiguration,
@@ -792,24 +780,17 @@ function Test-VRouterAgentIntegration {
         $Job.StepQuiet($MyInvocation.MyCommand.Name, {
             Write-Host "===> Running: Test-FlowsAreInjectedOnIcmpTraffic"
 
+            $TenantConfiguration = $TestConfiguration.DockerDriverConfiguration.TenantConfiguration
+
             Write-Host "======> Given: Contrail compute services are started"
-            Clear-TestConfiguration -Session $Session1 -TestConfiguration $TestConfiguration
-            Initialize-ComputeServices -Session $Session1 -TestConfiguration $TestConfiguration
-            Clear-TestConfiguration -Session $Session2 -TestConfiguration $TestConfiguration
-            Initialize-ComputeServices -Session $Session2 -TestConfiguration $TestConfiguration
-            New-DockerNetwork -Session $Session1 -TestConfiguration $TestConfiguration `
-                -Name $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy1.Name `
-                -Network $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy1.Name `
-                -Subnet $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy1.Subnets[0]
-            New-DockerNetwork -Session $Session2 -TestConfiguration $TestConfiguration `
-                -Name $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy2.Name `
-                -Network $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy2.Name `
-                -Subnet $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy2.Subnets[0]
+            Initialize-ComputeNodes -Session1 $Session1 -Session2 $Session2 `
+                -Network1 $TenantConfiguration.NetworkWithPolicy1 -Network2 $TenantConfiguration.NetworkWithPolicy2 `
+                -TestConfiguration $TestConfiguration
             Start-Sleep -Seconds $WAIT_TIME_FOR_AGENT_INIT_IN_SECONDS
 
             Write-Host "======> When 2 containers belonging to different networks are running"
-            $Network1Name = $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy1.Name
-            $Network2Name = $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy2.Name
+            $Network1Name = $TenantConfiguration.NetworkWithPolicy1.Name
+            $Network2Name = $TenantConfiguration.NetworkWithPolicy2.Name
             $Container1Name = "jolly-lumberjack"
             $Container2Name = "juniper-tree"
 
@@ -1000,12 +981,17 @@ function Test-VRouterAgentIntegration {
         $Job.StepQuiet($MyInvocation.MyCommand.Name, {
             Write-Host "===> Running: Test-FlowsAreInjectedOnUdpTraffic"
 
+            $TenantConfiguration = $TestConfiguration.DockerDriverConfiguration.TenantConfiguration
+
             Write-Host "======> Given: Contrail compute services are started"
-            Initialize-ComputeNodeForFlowTests -Session $Session -TestConfiguration $TestConfiguration
+            Initialize-ComputeNodes -Session1 $Session -Session2 $Session `
+                -Network1 $TenantConfiguration.NetworkWithPolicy1 -Network2 $TenantConfiguration.NetworkWithPolicy2 `
+                -TestConfiguration $TestConfiguration
+            Start-Sleep -Seconds $WAIT_TIME_FOR_AGENT_INIT_IN_SECONDS
 
             Write-Host "======> When 2 containers belonging to different networks are running"
-            $Network1Name = $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy1.Name
-            $Network2Name = $TestConfiguration.DockerDriverConfiguration.TenantConfiguration.NetworkWithPolicy2.Name
+            $Network1Name = $TenantConfiguration.NetworkWithPolicy1.Name
+            $Network2Name = $TenantConfiguration.NetworkWithPolicy2.Name
             $Container1Name = "jolly-lumberjack"
             $Container2Name = "juniper-tree"
 
@@ -1051,14 +1037,9 @@ function Test-VRouterAgentIntegration {
             $TenantConfiguration = $TestConfiguration.DockerDriverConfiguration.TenantConfiguration
 
             Write-Host "======> Given: Contrail compute services are started on two compute nodes"
-            Initialize-ComputeNode `
-                -Session $Session1 `
-                -TestConfiguration $TestConfiguration `
-                -Networks @($TenantConfiguration.NetworkWithPolicy1)
-            Initialize-ComputeNode `
-                -Session $Session2 `
-                -TestConfiguration $TestConfiguration `
-                -Networks @($TenantConfiguration.NetworkWithPolicy2)
+            Initialize-ComputeNodes -Session1 $Session1 -Session2 $Session2 `
+                -Network1 $TenantConfiguration.NetworkWithPolicy1 -Network2 $TenantConfiguration.NetworkWithPolicy2 `
+                -TestConfiguration $TestConfiguration
             Start-Sleep -Seconds $WAIT_TIME_FOR_AGENT_INIT_IN_SECONDS
 
             Write-Host "======> When 2 containers belonging to different networks are running"


### PR DESCRIPTION
Since https://github.com/codilime/contrail-vrouter/pull/166 is merged, we can enable networks with policies in UDP test.

Also, do not create default network when it's not used.

